### PR TITLE
Add Chrome extension for Gemini Flashcards Tutor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,59 @@
-# gemini-study-buddy
-Gemini Flashcards Tutor is a Chrome Extension that transforms any webpage, YouTube video, or online document into a personalized study tool using Google Gemini Flash 2.0.  With just one click, it extracts key concepts, generates summaries, flashcards, and Q&amp;A quizzes, and helps students and professionals retain knowledge more effectively.
+# Gemini Flashcards Tutor
+
+Gemini Flashcards Tutor is a Chrome extension that turns any article, research paper, or video transcript into a personalized study guide powered by Google Gemini Flash 2.0. Highlight the part you care about or let the extension read the entire page to instantly receive summaries, flashcards, and self-check quizzes tailored to your learning goals.
+
+## Features
+
+- **One-click summaries** – distill complex pages into digestible bullet points and actionable takeaways.
+- **AI-generated flashcards** – create 6-10 question/answer pairs in Markdown that you can copy into your favourite spaced repetition tool.
+- **Quick quizzes** – produce five multiple-choice questions with explanations to reinforce understanding.
+- **Focus-aware prompts** – optionally add study goals (exam, certification, audience, etc.) or highlight a passage to steer the response.
+- **Local settings** – your Gemini API key and focus preferences are saved securely with `chrome.storage.sync` on your Google account.
+
+## Requirements
+
+- Google Chrome 115+ (Manifest V3 support).
+- A Google account with access to [Google AI Studio](https://aistudio.google.com/) and a Gemini API key with access to Gemini Flash 2.0.
+
+## Installation
+
+1. Clone or download this repository and keep the `extension/` folder intact.
+2. Open Google Chrome and navigate to `chrome://extensions`.
+3. Enable **Developer mode** in the top-right corner.
+4. Click **Load unpacked** and select the `extension/` directory from this project.
+5. The Gemini Flashcards Tutor icon will appear in your toolbar. Pin it for quick access.
+
+## Usage
+
+1. Open a webpage, PDF (viewed in Chrome), or YouTube transcript that you want to study.
+2. (Optional) Highlight a section to prioritize that text. Otherwise the full page will be analysed.
+3. Click the Gemini Flashcards Tutor icon.
+4. Paste your Gemini API key the first time you use the extension—it will be stored in Chrome Sync for future sessions.
+5. Add any focus notes (e.g., “focus on exam-style questions” or “teach this to beginners”).
+6. Choose **Generate Summary**, **Generate Flashcards**, or **Generate Quiz**.
+7. Review the generated study aids directly in the popup and copy them into your notes or study app.
+
+> **Tip:** If the page is very long, the extension trims the context that is sent to Gemini. You can refine the focus by highlighting the most important section before generating content.
+
+## File structure
+
+```
+extension/
+├── manifest.json    # Chrome extension manifest (MV3)
+├── popup.css        # Styling for the popup UI
+├── popup.html       # Extension popup markup
+└── popup.js         # Popup logic, Gemini API calls, and content extraction
+```
+
+## Privacy & limits
+
+- The extension only sends text you explicitly request (highlighted selection or page contents) to the Gemini API. Nothing is stored on external servers.
+- Gemini API usage is subject to your Google AI Studio quota and billing. Handle API keys carefully—treat them like passwords and rotate if needed.
+
+## Development notes
+
+- The extension uses `chrome.scripting.executeScript` to read page content on demand. Restricted pages such as the Chrome Web Store cannot be accessed.
+- Responses are rendered as plain text to keep the popup lightweight. Paste them into a Markdown editor for richer formatting.
+- To customize prompts or behaviour, edit `extension/popup.js` and reload the unpacked extension from `chrome://extensions`.
+
+Enjoy faster studying with Gemini Flashcards Tutor! 🚀

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,18 @@
+{
+  "manifest_version": 3,
+  "name": "Gemini Flashcards Tutor",
+  "version": "1.0.0",
+  "description": "Turn any web page into a personalized study guide with summaries, flashcards, and quizzes powered by Google Gemini Flash.",
+  "permissions": [
+    "activeTab",
+    "scripting",
+    "storage"
+  ],
+  "host_permissions": [
+    "https://generativelanguage.googleapis.com/*"
+  ],
+  "action": {
+    "default_title": "Gemini Flashcards Tutor",
+    "default_popup": "popup.html"
+  }
+}

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -1,0 +1,154 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --bg: #f8fafc;
+  --fg: #0f172a;
+  --muted: #475569;
+  --accent: #2563eb;
+  --accent-light: #dbeafe;
+  --border: #e2e8f0;
+}
+
+body {
+  margin: 0;
+  padding: 16px;
+  width: 360px;
+  background: var(--bg);
+  color: var(--fg);
+}
+
+header {
+  margin-bottom: 12px;
+  text-align: left;
+}
+
+h1 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+h2 {
+  font-size: 1rem;
+  margin-bottom: 6px;
+}
+
+.tagline {
+  margin: 4px 0 0;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.section {
+  margin-bottom: 14px;
+}
+
+.field-label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+input,
+textarea {
+  width: 100%;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  padding: 8px 10px;
+  font-size: 0.95rem;
+  box-sizing: border-box;
+  background: white;
+  color: inherit;
+}
+
+textarea {
+  resize: vertical;
+  min-height: 60px;
+}
+
+.hint {
+  font-size: 0.75rem;
+  color: var(--muted);
+  margin-top: 4px;
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+}
+
+button {
+  flex: 1;
+  border: none;
+  border-radius: 999px;
+  padding: 10px 14px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  background: var(--accent);
+  color: white;
+  cursor: pointer;
+  transition: transform 0.1s ease, box-shadow 0.1s ease, background 0.2s ease;
+}
+
+button:hover:not([disabled]) {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(37, 99, 235, 0.2);
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: progress;
+}
+
+#status {
+  min-height: 24px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+#status.error {
+  color: #dc2626;
+}
+
+#contextPreview {
+  max-height: 160px;
+  overflow: auto;
+  white-space: pre-wrap;
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 8px;
+  font-size: 0.8rem;
+}
+
+#result {
+  max-height: 320px;
+  overflow: auto;
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 12px;
+  line-height: 1.5;
+  font-size: 0.9rem;
+  white-space: pre-wrap;
+}
+
+.spinner {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid var(--accent-light);
+  border-top-color: var(--accent);
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Gemini Flashcards Tutor</title>
+    <link rel="stylesheet" href="popup.css" />
+  </head>
+  <body>
+    <header>
+      <h1>Gemini Flashcards Tutor</h1>
+      <p class="tagline">Generate summaries, flashcards, and quizzes from any page.</p>
+    </header>
+
+    <section class="section">
+      <label class="field-label" for="apiKey">Gemini API key</label>
+      <input
+        id="apiKey"
+        type="password"
+        placeholder="Paste your Google AI Studio API key"
+        autocomplete="off"
+      />
+      <p class="hint">Stored locally with chrome.storage.sync.</p>
+    </section>
+
+    <section class="section">
+      <label class="field-label" for="focus">Focus areas (optional)</label>
+      <textarea
+        id="focus"
+        rows="2"
+        placeholder="Key topics, exam goals, or the audience you want to study for"
+      ></textarea>
+    </section>
+
+    <section class="actions section">
+      <button id="summaryBtn" data-action="summary">Generate Summary</button>
+      <button id="flashcardBtn" data-action="flashcards">Generate Flashcards</button>
+      <button id="quizBtn" data-action="quiz">Generate Quiz</button>
+    </section>
+
+    <section class="section" id="status" role="status"></section>
+
+    <section class="section" id="contextSection" hidden>
+      <h2>Context extracted from the page</h2>
+      <pre id="contextPreview"></pre>
+    </section>
+
+    <section class="section" id="resultSection" hidden>
+      <h2>Gemini output</h2>
+      <div id="result"></div>
+    </section>
+
+    <template id="loadingTemplate">
+      <div class="spinner" aria-hidden="true"></div>
+      <span>Asking Gemini...</span>
+    </template>
+
+    <script src="popup.js" type="module"></script>
+  </body>
+</html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,0 +1,293 @@
+const MODEL = "gemini-1.5-flash-latest";
+const API_BASE = `https://generativelanguage.googleapis.com/v1beta/models/${MODEL}:generateContent`;
+const MAX_CONTEXT_LENGTH = 6000;
+
+const apiKeyInput = document.getElementById("apiKey");
+const focusInput = document.getElementById("focus");
+const statusEl = document.getElementById("status");
+const contextSection = document.getElementById("contextSection");
+const contextPreview = document.getElementById("contextPreview");
+const resultSection = document.getElementById("resultSection");
+const resultEl = document.getElementById("result");
+const loadingTemplate = document.getElementById("loadingTemplate");
+
+const actionButtons = Array.from(document.querySelectorAll("button[data-action]"));
+
+const storage = {
+  async get(keys) {
+    return new Promise((resolve, reject) => {
+      try {
+        chrome.storage.sync.get(keys, (result) => {
+          const error = chrome.runtime.lastError;
+          if (error) {
+            reject(new Error(error.message));
+          } else {
+            resolve(result);
+          }
+        });
+      } catch (error) {
+        reject(error);
+      }
+    });
+  },
+  async set(items) {
+    return new Promise((resolve, reject) => {
+      try {
+        chrome.storage.sync.set(items, () => {
+          const error = chrome.runtime.lastError;
+          if (error) {
+            reject(new Error(error.message));
+          } else {
+            resolve();
+          }
+        });
+      } catch (error) {
+        reject(error);
+      }
+    });
+  },
+};
+
+init();
+
+function init() {
+  restoreSettings();
+  wireAutosave(apiKeyInput, "apiKey");
+  wireAutosave(focusInput, "focusPreferences");
+
+  actionButtons.forEach((button) => {
+    button.addEventListener("click", () => handleGenerate(button.dataset.action));
+  });
+
+  setStatus("Ready when you are! Highlight text for a tighter focus.");
+}
+
+async function restoreSettings() {
+  try {
+    const stored = await storage.get(["apiKey", "focusPreferences"]);
+    if (stored.apiKey) {
+      apiKeyInput.value = stored.apiKey;
+    }
+    if (stored.focusPreferences) {
+      focusInput.value = stored.focusPreferences;
+    }
+  } catch (error) {
+    console.warn("Unable to restore settings", error);
+  }
+}
+
+function wireAutosave(input, key) {
+  let timeoutId;
+  const persist = () => {
+    const value = input.value.trim();
+    storage.set({ [key]: value }).catch((error) => {
+      console.warn(`Failed to save ${key}`, error);
+    });
+  };
+
+  input.addEventListener("change", persist);
+  input.addEventListener("blur", persist);
+  input.addEventListener("input", () => {
+    clearTimeout(timeoutId);
+    timeoutId = setTimeout(persist, 400);
+  });
+}
+
+async function handleGenerate(action) {
+  const apiKey = apiKeyInput.value.trim();
+  if (!apiKey) {
+    setStatus("Add your Gemini API key to get started.", { error: true });
+    apiKeyInput.focus();
+    return;
+  }
+
+  try {
+    setButtonsDisabled(true);
+    setStatus("Collecting the page context...", { loading: true });
+    const focus = focusInput.value.trim();
+    const contextInfo = await collectPageContext();
+
+    if (!contextInfo.text) {
+      throw new Error("Couldn't read any text on this page. Try selecting the content first.");
+    }
+
+    showContext(contextInfo);
+
+    setStatus("Talking with Gemini Flash...", { loading: true });
+    const prompt = buildPrompt(action, contextInfo, focus);
+    const output = await callGemini(apiKey, prompt);
+    showResult(output);
+    setStatus("Done! Review the study material below.");
+  } catch (error) {
+    console.error(error);
+    const message = error?.message || "Something went wrong while generating.";
+    setStatus(message, { error: true });
+  } finally {
+    setButtonsDisabled(false);
+  }
+}
+
+function setButtonsDisabled(disabled) {
+  actionButtons.forEach((button) => {
+    button.disabled = disabled;
+  });
+}
+
+function setStatus(message, { loading = false, error = false } = {}) {
+  statusEl.innerHTML = "";
+  statusEl.classList.toggle("error", Boolean(error));
+  statusEl.hidden = !message && !loading;
+
+  if (loading) {
+    const fragment = loadingTemplate.content.cloneNode(true);
+    const span = fragment.querySelector("span");
+    if (span) {
+      span.textContent = message || "Working...";
+    }
+    statusEl.appendChild(fragment);
+  } else if (message) {
+    statusEl.textContent = message;
+  }
+}
+
+async function collectPageContext() {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  if (!tab?.id) {
+    throw new Error("Couldn't find the active tab.");
+  }
+
+  try {
+    const [injectionResult] = await chrome.scripting.executeScript({
+      target: { tabId: tab.id },
+      func: () => {
+        const selection = window.getSelection()?.toString() ?? "";
+        const bodyText = document.body?.innerText ?? "";
+        return {
+          selection: selection.trim(),
+          body: bodyText.trim().replace(/\s+\n/g, "\n").replace(/\n{3,}/g, "\n\n"),
+        };
+      },
+    });
+
+    const { selection, body } = injectionResult?.result ?? { selection: "", body: "" };
+    let text = selection || body || "";
+    const usedSelection = Boolean(selection);
+    let truncated = false;
+
+    if (text.length > MAX_CONTEXT_LENGTH) {
+      truncated = true;
+      text = `${text.slice(0, MAX_CONTEXT_LENGTH)}\n\n[Context truncated after ${MAX_CONTEXT_LENGTH} characters]`;
+    }
+
+    return { text, truncated, usedSelection };
+  } catch (error) {
+    console.error("Failed to inject script", error);
+    throw new Error("Chrome couldn't access this tab. Try reloading the page and opening the extension again.");
+  }
+}
+
+function showContext({ text, truncated, usedSelection }) {
+  if (!text) {
+    contextSection.hidden = true;
+    return;
+  }
+
+  contextPreview.textContent = text;
+  contextSection.hidden = false;
+
+  const heading = contextSection.querySelector("h2");
+  if (heading) {
+    if (usedSelection) {
+      heading.textContent = "Context from your highlighted selection";
+    } else {
+      heading.textContent = "Context extracted from the page";
+    }
+    if (truncated) {
+      heading.textContent += " (truncated)";
+    }
+  }
+}
+
+function showResult(output) {
+  resultEl.textContent = output;
+  resultSection.hidden = false;
+}
+
+function buildPrompt(action, contextInfo, focus) {
+  const { text, truncated, usedSelection } = contextInfo;
+  const focusLine = focus ? `\nLearner goals or focus areas: ${focus}` : "";
+  const selectionNote = usedSelection
+    ? "\nThe learner highlighted specific text. Prioritize the highlighted material while still using broader context when relevant."
+    : "";
+  const truncationNote = truncated
+    ? "\nThe context was truncated for length. Respond using only the provided portion."
+    : "";
+
+  let task;
+  switch (action) {
+    case "summary":
+      task = `Create a study summary that captures the essential ideas, definitions, and cause/effect relationships.
+- Start with a short paragraph that frames the topic.
+- Follow with 3-6 bullet points of key takeaways using plain language.
+- Close with one actionable tip or mnemonic that helps remember the material.`;
+      break;
+    case "flashcards":
+      task = `Produce 6-10 concise flashcards formatted as Markdown.
+For each card write a bold question line followed by an indented answer line that learners can quickly review.
+Vary between concept, definition, and application questions.`;
+      break;
+    case "quiz":
+      task = `Generate a short self-check quiz in Markdown with 5 multiple-choice questions.
+For each question provide four answer options labeled A-D and mark the correct answer on a new line starting with "Answer:".
+Include a one-sentence explanation after each answer to reinforce learning.`;
+      break;
+    default:
+      task = "Summarize the material in a learner-friendly way.";
+  }
+
+  return `You are Gemini Flashcards Tutor, an expert AI study assistant powered by Google Gemini Flash 2.0.
+Use the context provided to craft the requested study aid.${selectionNote}${truncationNote}${focusLine}
+
+Context:
+"""
+${text}
+"""
+
+Task:
+${task}`;
+}
+
+async function callGemini(apiKey, prompt) {
+  const response = await fetch(`${API_BASE}?key=${encodeURIComponent(apiKey)}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      contents: [
+        {
+          role: "user",
+          parts: [{ text: prompt }],
+        },
+      ],
+    }),
+  });
+
+  const payload = await response.json().catch(() => ({}));
+
+  if (!response.ok) {
+    const errorMessage = payload?.error?.message || `Gemini API error (${response.status})`;
+    throw new Error(errorMessage);
+  }
+
+  const text = payload?.candidates?.[0]?.content?.parts
+    ?.map((part) => part?.text ?? "")
+    .join("")
+    .trim();
+
+  if (!text) {
+    throw new Error("Gemini returned an empty response. Try again or refine your focus notes.");
+  }
+
+  return text;
+}


### PR DESCRIPTION
## Summary
- add a Chrome extension scaffold with manifest and popup UI for Gemini Flashcards Tutor
- implement popup logic to capture page context, call the Gemini Flash API, and display summaries, flashcards, or quizzes
- document installation, usage, and development notes for the extension

## Testing
- not run (Chrome extension manual testing required)


------
https://chatgpt.com/codex/tasks/task_e_68c97dee221883339e404870ddbd7c7d