### PR TITLE
Allow in-popup Gemini API key entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Gemini Flashcards Tutor is a Chrome extension that turns any article, research p
 - **One-click summaries** – distill complex pages into digestible bullet points and actionable takeaways.
 - **AI-generated flashcards** – create 6-10 question/answer pairs in Markdown that you can copy into your favourite spaced repetition tool.
 - **Quick quizzes** – produce five multiple-choice questions with explanations to reinforce understanding.
-- **Environment-based API key** – keep your Gemini API key in `extension/.env` or paste it at runtime; the extension never stores it in Chrome Sync.
+- **In-popup API key entry** – paste your Gemini API key directly into the popup; it only lives for the current session and never leaves your device.
 
 ## Requirements
 
@@ -21,14 +21,14 @@ Gemini Flashcards Tutor is a Chrome extension that turns any article, research p
 3. Enable **Developer mode** in the top-right corner.
 4. Click **Load unpacked** and select the `extension/` directory from this project.
 5. The Gemini Flashcards Tutor icon will appear in your toolbar. Pin it for quick access.
-6. Create a file named `.env` inside the `extension/` folder that contains a line like `API_KEY=your_gemini_key_here`. The extension reads this file automatically when generating content.
+6. Open the extension popup and paste your Gemini API key when prompted. The key is only used locally while the popup remains open.
 
 ## Usage
 
 1. Open a webpage, PDF (viewed in Chrome), or YouTube transcript that you want to study.
 2. (Optional) Highlight a section to prioritize that text. Otherwise the full page will be analysed.
 3. Click the Gemini Flashcards Tutor icon.
-4. Add your Gemini API key to `extension/.env` before generating, or paste it into the popup for a single session.
+4. Paste your Gemini API key into the popup and click **Load key**. The key is kept in-memory only for that session.
 5. Choose **Generate Summary**, **Generate Flashcards**, or **Generate Quiz**.
 6. Review the generated study aids directly in the popup and copy them into your notes or study app.
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -13,15 +13,5 @@
   "action": {
     "default_title": "Gemini Flashcards Tutor",
     "default_popup": "popup.html"
-  },
-  "web_accessible_resources": [
-    {
-      "resources": [
-        ".env"
-      ],
-      "matches": [
-        "<all_urls>"
-      ]
-    }
-  ]
+  }
 }

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -86,6 +86,43 @@ h2 {
   gap: 10px;
 }
 
+#keySection .hint {
+  display: block;
+  margin-bottom: 8px;
+}
+
+.key-input {
+  display: flex;
+  gap: 10px;
+}
+
+#apiKeyInput {
+  flex: 1;
+  border-radius: 999px;
+  padding: 11px 16px;
+  font-size: 0.85rem;
+  color: var(--fg);
+  background: rgba(15, 23, 42, 0.45);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+#apiKeyInput::placeholder {
+  color: var(--muted);
+}
+
+#apiKeyInput:focus {
+  outline: none;
+  border-color: rgba(96, 165, 250, 0.7);
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.35);
+}
+
+#apiKeyInput[data-loaded="true"] {
+  border-color: rgba(96, 165, 250, 0.8);
+  box-shadow: 0 0 0 2px rgba(96, 165, 250, 0.3);
+}
+
 button {
   flex: 1;
   border: 1px solid transparent;
@@ -114,6 +151,12 @@ button:disabled {
   opacity: 0.7;
   cursor: progress;
   box-shadow: none;
+}
+
+button.compact {
+  flex: 0 0 auto;
+  padding: 11px 18px;
+  white-space: nowrap;
 }
 
 #status {

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -11,8 +11,23 @@
       <header class="hero">
         <h1>Gemini Flashcards Tutor</h1>
         <p class="tagline">Generate summaries, flashcards, and quizzes from any page.</p>
-        <p class="hint hint-inline">The extension reads your Gemini API key from <code>extension/.env</code>.</p>
+        <p class="hint hint-inline">Paste your Gemini API key below when you're ready to generate.</p>
       </header>
+
+      <section class="section" id="keySection" aria-labelledby="apiKeyLabel">
+        <label class="hint" id="apiKeyLabel" for="apiKeyInput">Your key stays on this device and isn't stored after you close the popup.</label>
+        <div class="key-input">
+          <input
+            id="apiKeyInput"
+            type="password"
+            placeholder="Paste your Gemini API key"
+            autocomplete="off"
+            spellcheck="false"
+            aria-describedby="apiKeyLabel"
+          />
+          <button id="apiKeyButton" class="compact" type="button">Load key</button>
+        </div>
+      </section>
 
       <section class="section" id="status" role="status"></section>
 


### PR DESCRIPTION
## Summary
- replace the previous .env-based Gemini API key lookup with a manual key input inside the popup
- refresh the popup markup and styles to include the new key loader and give visual feedback when a key is active
- update the manifest and README so the extension no longer references the .env file

## Testing
- not run (extension UI change)


------
https://chatgpt.com/codex/tasks/task_e_68cadf2454388333bb7ec5275e5c38ec